### PR TITLE
refactor: borrow header slices & make args/enums Copy; streamline config helpers

### DIFF
--- a/src/args/config/get.rs
+++ b/src/args/config/get.rs
@@ -2,19 +2,19 @@ use crate::args::config::Normalizable;
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone, Copy)]
 pub struct GetArgs {
     #[command(subcommand)]
     pub command: Option<GetCommands>,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Clone, Copy)]
 pub enum GetCommands {
     Table(GetTableArgs),
     Dps(GetDpsArgs),
 }
 
-#[derive(Args, Debug, Clone, Serialize, Default)]
+#[derive(Args, Debug, Clone, Copy, Serialize, Default)]
 pub struct GetTableArgs {
     #[arg(short, long)]
     pub all: bool,
@@ -30,7 +30,7 @@ impl Normalizable for GetTableArgs {
     }
 }
 
-#[derive(Args, Debug, Clone, Serialize, Default)]
+#[derive(Args, Debug, Clone, Copy, Serialize, Default)]
 pub struct GetDpsArgs {
     #[arg(short, long)]
     pub all: bool,

--- a/src/args/config/mod.rs
+++ b/src/args/config/mod.rs
@@ -29,13 +29,13 @@ pub trait Normalizable: Serialize + Sized {
     }
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub struct ConfigArgs {
     #[command(subcommand)]
     pub command: ConfigCommands,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Clone)]
 pub enum ConfigCommands {
     Set(SetArgs),
     Get(GetArgs),

--- a/src/args/config/reset.rs
+++ b/src/args/config/reset.rs
@@ -2,19 +2,19 @@ use crate::args::config::Normalizable;
 use clap::{Args, Subcommand};
 use serde::{Deserialize, Serialize};
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone, Copy)]
 pub struct ResetArgs {
     #[command(subcommand)]
     pub command: Option<ResetCommands>,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Clone, Copy)]
 pub enum ResetCommands {
     Table(ResetTableArgs),
     Dps(ResetDpsArgs),
 }
 
-#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[derive(Args, Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct ResetTableArgs {
     #[arg(short, long)]
     pub all: bool,
@@ -30,7 +30,7 @@ impl Normalizable for ResetTableArgs {
     }
 }
 
-#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[derive(Args, Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct ResetDpsArgs {
     #[arg(short, long)]
     pub all: bool,

--- a/src/args/config/set.rs
+++ b/src/args/config/set.rs
@@ -2,19 +2,19 @@ use crate::config::model::dps::DpsHeader;
 use crate::config::model::table::{TableModifiers, TablePresets};
 use clap::{Args, Subcommand};
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub struct SetArgs {
     #[command(subcommand)]
     pub command: SetCommands,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Clone)]
 pub enum SetCommands {
     Table(SetTableArgs),
     Dps(SetDpsArgs),
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone, Copy)]
 pub struct SetTableArgs {
     #[arg(long, value_enum)]
     pub preset: Option<TablePresets>,
@@ -22,7 +22,7 @@ pub struct SetTableArgs {
     pub modifier: Option<TableModifiers>,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub struct SetDpsArgs {
     #[arg(long, value_enum)]
     pub headers: Option<Vec<DpsHeader>>,

--- a/src/args/dps.rs
+++ b/src/args/dps.rs
@@ -2,7 +2,7 @@ use crate::config::model::dps::DpsHeader;
 use crate::config::model::table::{TableModifiers, TablePresets};
 use clap::Args;
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 /// Pretty replacement for `docker ps`
 pub struct DpsArgs {
     /// Show all containers (default shows just running)

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -23,7 +23,7 @@ impl Cli {
     }
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Clone)]
 pub enum Commands {
     Dps(DpsArgs),
     Config(ConfigArgs),

--- a/src/cmd/config/get.rs
+++ b/src/cmd/config/get.rs
@@ -18,15 +18,15 @@ pub fn get(args: GetArgs) -> Result<()> {
     if let Some(command) = args.command {
         match command {
             GetCommands::Table(args) => {
-                config_table = table(config_table, args)?;
+                table(&mut config_table, &cfg, args)?;
             }
             GetCommands::Dps(args) => {
-                config_table = dps(config_table, args)?;
+                dps(&mut config_table, &cfg, args)?;
             }
         }
     } else {
-        config_table = table(config_table, GetTableArgs::default())?;
-        config_table = dps(config_table, GetDpsArgs::default())?;
+        table(&mut config_table, &cfg, GetTableArgs::default())?;
+        dps(&mut config_table, &cfg, GetDpsArgs::default())?;
     }
 
     println!("{}", config_table);
@@ -34,9 +34,8 @@ pub fn get(args: GetArgs) -> Result<()> {
     Ok(())
 }
 
-fn table(mut config_table: Table, mut args: GetTableArgs) -> Result<Table> {
-    let cfg = Config::load()?;
-    args = args.normalize();
+fn table(config_table: &mut Table, cfg: &Config, args: GetTableArgs) -> Result<()> {
+    let args = args.normalize();
 
     if args.preset || args.all {
         let table_row: TableRow = vec!["table.preset".into(), cfg.table.preset.to_string()];
@@ -47,17 +46,16 @@ fn table(mut config_table: Table, mut args: GetTableArgs) -> Result<Table> {
         config_table.add_row(table_row);
     }
 
-    Ok(config_table)
+    Ok(())
 }
 
-fn dps(mut config_table: Table, mut args: GetDpsArgs) -> Result<Table> {
-    let cfg = Config::load()?;
-    args = args.normalize();
+fn dps(config_table: &mut Table, cfg: &Config, args: GetDpsArgs) -> Result<()> {
+    let args = args.normalize();
 
     if args.headers || args.all {
         let table_row: TableRow = vec!["dps.headers".into(), format!("{:?}", cfg.dps.headers)];
         config_table.add_row(table_row);
     }
 
-    Ok(config_table)
+    Ok(())
 }

--- a/src/cmd/config/reset.rs
+++ b/src/cmd/config/reset.rs
@@ -21,9 +21,9 @@ pub fn reset(args: ResetArgs) -> Result<()> {
     }
 }
 
-fn table(mut args: ResetTableArgs) -> Result<()> {
+fn table(args: ResetTableArgs) -> Result<()> {
     let mut cfg = Config::load()?;
-    args = args.normalize();
+    let args = args.normalize();
 
     if args.all {
         cfg.table = TableConfig::default();
@@ -40,9 +40,9 @@ fn table(mut args: ResetTableArgs) -> Result<()> {
     cfg.save()
 }
 
-fn dps(mut args: ResetDpsArgs) -> Result<()> {
+fn dps(args: ResetDpsArgs) -> Result<()> {
     let mut cfg = Config::load()?;
-    args = args.normalize();
+    let args = args.normalize();
 
     if args.all {
         cfg.dps = DpsConfig::default();

--- a/src/cmd/dps.rs
+++ b/src/cmd/dps.rs
@@ -8,8 +8,8 @@ use anyhow::Result;
 pub fn run(args: DpsArgs) -> Result<()> {
     let stdout = utils::docker::ps(
         args.all,
-        args.headers.clone(),
-        args.add_headers.clone(),
+        args.headers.as_deref(),
+        args.add_headers.as_deref(),
         args.last,
         args.latest,
         args.no_trunc,

--- a/src/config/model/dps.rs
+++ b/src/config/model/dps.rs
@@ -2,7 +2,7 @@ use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DpsConfig {
     pub headers: Vec<DpsHeader>,
 }
@@ -21,7 +21,7 @@ impl Default for DpsConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, ValueEnum)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, ValueEnum)]
 pub enum DpsHeader {
     Id,
     Names,

--- a/src/config/model/mod.rs
+++ b/src/config/model/mod.rs
@@ -5,7 +5,7 @@ use table::TableConfig;
 pub mod dps;
 pub mod table;
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
     pub table: TableConfig,
     pub dps: DpsConfig,

--- a/src/config/model/table.rs
+++ b/src/config/model/table.rs
@@ -3,13 +3,13 @@ use comfy_table::{modifiers, presets};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
 pub struct TableConfig {
     pub preset: TablePresets,
     pub modifier: TableModifiers,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, ValueEnum, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, ValueEnum, Default)]
 pub enum TablePresets {
     AsciiFull,
     AsciiFullCondensed,
@@ -34,7 +34,7 @@ impl fmt::Display for TablePresets {
 }
 
 impl TablePresets {
-    pub fn to_preset(&self) -> &str {
+    pub fn to_preset(self) -> &'static str {
         match self {
             TablePresets::AsciiFull => presets::ASCII_FULL,
             TablePresets::AsciiFullCondensed => presets::ASCII_FULL_CONDENSED,
@@ -53,7 +53,7 @@ impl TablePresets {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, ValueEnum, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, ValueEnum, Default)]
 pub enum TableModifiers {
     #[default]
     Utf8RoundCorners,
@@ -67,7 +67,7 @@ impl fmt::Display for TableModifiers {
 }
 
 impl TableModifiers {
-    pub fn to_modifier(&self) -> &str {
+    pub fn to_modifier(self) -> &'static str {
         match self {
             TableModifiers::Utf8RoundCorners => modifiers::UTF8_ROUND_CORNERS,
             TableModifiers::Utf8SolidInnerBorders => modifiers::UTF8_SOLID_INNER_BORDERS,


### PR DESCRIPTION
- refactor(utils/docker): accept headers as Option<&[DpsHeader]> and compose --format with chained iterators; update call sites to use .as_deref()
- refactor(cmd/config): pass &Config and &mut Table to table()/dps() helpers instead of returning Table; drop redundant Config::load(); normalize args immutably
- chore(types): derive Clone/Copy for CLI args (GetArgs, ResetArgs, SetArgs, DpsArgs) and config models/enums (Config, DpsConfig, TableConfig, TablePresets, TableModifiers, DpsHeader)
- perf: reduce unnecessary Vec clones and allocations when building header strings