### PR TITLE
fix(deb): enable automatic dependency detection for Ubuntu/Debian packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license-file = ["LICENSE", "0"]
 extended-description = "EnderCliTools is a lightweight collection of CLI utilities that make working in the terminal faster and more convenient."
 section = "utils"
 priority = "optional"
-depends = ""
+depends = "$auto"
 assets = [
     ["target/release/EnderCliTools", "/usr/bin/enderclitools", "755"],
     ["debian-bin/ect", "/usr/bin/ect", "755"],


### PR DESCRIPTION
fix(deb): set depends="$auto" in Cargo.toml to include required Ubuntu/Debian runtime dependencies in the .deb