### PR TITLE
fix: add Debian alias for 'dcps' to cargo-deb assets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,5 @@ assets = [
     ["target/release/EnderCliTools", "/usr/bin/enderclitools", "755"],
     ["debian-bin/ect", "/usr/bin/ect", "755"],
     ["debian-bin/dps", "/usr/bin/dps", "755"],
+    ["debian-bin/dcps", "/usr/bin/dcps", "755"],
 ]


### PR DESCRIPTION
- fix: add Debian alias for `dcps` by including `debian-bin/dcps` in cargo-deb assets (installs to /usr/bin/dcps)